### PR TITLE
Remove deprecated failure in favor of thiserror.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 authors = ["OKAMURA, Yasunobu <okamura@informationsea.info>"]
 readme = "README.md"
-description = "Rust implentation of bgzip"
+description = "Rust implementation of bgzip"
 homepage = "https://github.com/informationsea/bgzip-rs"
 repository = "https://github.com/informationsea/bgzip-rs"
 license = "MIT"
@@ -19,8 +19,9 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 flate2 = "1"
-failure = "0.1"
+thiserror = "1.0"
 
 [dev-dependencies]
 csv = "1"
 clap = "2"
+tempfile = "3"

--- a/examples/bgzip.rs
+++ b/examples/bgzip.rs
@@ -1,4 +1,4 @@
-use bgzip::{BGZFError, BGZFErrorKind, BGZFWriter};
+use bgzip::{BGZFError, BGZFWriter};
 use clap::{App, Arg};
 use std::fs;
 use std::io;
@@ -111,7 +111,9 @@ fn main() -> Result<(), BGZFError> {
                 };
 
                 if Path::new(&output_filename).exists() && !matches.is_present("force") {
-                    return Err(BGZFErrorKind::Other("already exist").into());
+                    return Err(BGZFError::Other {
+                        message: "already exist",
+                    });
                 }
                 (
                     Mode::Decompress,
@@ -120,7 +122,9 @@ fn main() -> Result<(), BGZFError> {
             } else {
                 let output_filename = format!("{}.gz", x);
                 if Path::new(&output_filename).exists() && !matches.is_present("force") {
-                    return Err(BGZFErrorKind::Other("already exist").into());
+                    return Err(BGZFError::Other {
+                        message: "already exist",
+                    });
                 }
 
                 (Mode::Compress, Box::new(fs::File::create(output_filename)?))

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,73 +1,18 @@
-use failure::{Backtrace, Context, Fail};
-use std::fmt::{self, Display};
+use thiserror::Error;
 
-/// A BGZF error
-#[derive(Debug)]
-pub struct BGZFError {
-    inner: failure::Context<BGZFErrorKind>,
-}
-
-/// A BGZF error kind.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
-pub enum BGZFErrorKind {
-    #[fail(display = "Failed to parse header at position: {}", _0)]
-    HeaderParseError(u64),
-    #[fail(display = "not tabix format")]
+/// A BGZF error.
+#[derive(Debug, Error)]
+pub enum BGZFError {
+    #[error("Failed to parse header at position: {position}")]
+    HeaderParseError { position: u64 },
+    #[error("not tabix format")]
     NotTabix,
-    #[fail(display = "not BGZF format")]
+    #[error("not BGZF format")]
     NotBGZF,
-    #[fail(display = "I/O Error")]
-    IoError,
-    #[fail(display = "Utf8 Error")]
-    Utf8Error,
-    #[fail(display = "Error: {}", _0)]
-    Other(&'static str),
-}
-
-impl Fail for BGZFError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl Display for BGZFError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self.inner, f)
-    }
-}
-
-impl BGZFError {
-    pub fn kind(&self) -> BGZFErrorKind {
-        *self.inner.get_context()
-    }
-}
-
-impl From<BGZFErrorKind> for BGZFError {
-    fn from(kind: BGZFErrorKind) -> BGZFError {
-        BGZFError {
-            inner: Context::new(kind),
-        }
-    }
-}
-
-impl From<Context<BGZFErrorKind>> for BGZFError {
-    fn from(inner: Context<BGZFErrorKind>) -> BGZFError {
-        BGZFError { inner }
-    }
-}
-
-impl From<std::io::Error> for BGZFError {
-    fn from(e: std::io::Error) -> BGZFError {
-        e.context(BGZFErrorKind::IoError).into()
-    }
-}
-
-impl From<std::str::Utf8Error> for BGZFError {
-    fn from(e: std::str::Utf8Error) -> BGZFError {
-        e.context(BGZFErrorKind::Utf8Error).into()
-    }
+    #[error("I/O Error")]
+    IoError(#[from] std::io::Error),
+    #[error("Utf8 Error")]
+    Utf8Error(#[from] std::str::Utf8Error),
+    #[error("Error: {message:}")]
+    Other { message: &'static str },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod read;
 pub mod tabix;
 mod write;
 
-pub use error::{BGZFError, BGZFErrorKind};
+pub use error::BGZFError;
 pub use read::BGZFReader;
 pub use write::BGZFWriter;
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -92,10 +92,14 @@ impl<R: Read + Seek> BGZFReader<R> {
         let crc32 = self.reader.read_le_u32()?;
         let raw_length = self.reader.read_le_u32()?;
         if raw_length != buffer.len() as u32 {
-            return Err(BGZFErrorKind::Other("Unmatched length").into());
+            return Err(BGZFError::Other {
+                message: "Unmatched length",
+            });
         }
         if crc32 != loaded_crc32 {
-            return Err(BGZFErrorKind::Other("Unmatched CRC32").into());
+            return Err(BGZFError::Other {
+                message: "Unmatched CRC32",
+            });
         }
         self.cache_order.push(block_position);
         self.cache.insert(

--- a/src/tabix.rs
+++ b/src/tabix.rs
@@ -107,10 +107,7 @@ impl Tabix {
         let skip = reader.read_le_i32()?;
         let length_of_concatenated_sequence_names = reader.read_le_i32()?;
         let mut name_bytes: Vec<u8> =
-            Vec::with_capacity(length_of_concatenated_sequence_names.try_into().unwrap());
-        for _ in 0..length_of_concatenated_sequence_names {
-            name_bytes.push(0);
-        }
+            vec![0; length_of_concatenated_sequence_names.try_into().unwrap()];
         reader.read_exact(&mut name_bytes)?;
         let names = split_names(&name_bytes);
 


### PR DESCRIPTION
Hi,

Following my [issue](https://github.com/informationsea/bgzip-rs/issues/1), I've updated the crate to use `thiserror` in place of `failure`. `cargo test`, `cargo clippy` are all good with this PR. But please review it and see if I have not forgotten something. And when you are ready you can accept this PR, so all of us will be free from the deprecated `failure` crate  :)