### PR TITLE
Fix panic on BGZFReader::fill_buf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,4 +119,12 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_read_all() -> Result<(), BGZFError> {
+        let reader =
+            BGZFReader::new(fs::File::open("testfiles/common_all_20180418_half.vcf.gz")?);
+        for _line in reader.lines() {}
+        Ok(())
+    }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -127,7 +127,7 @@ impl<R: Read + Seek> BufRead for BGZFReader<R> {
         if remain_bytes > 0 {
             return Ok(&block.buffer[self.current_position_in_block..]);
         }
-        unreachable!()
+        Ok(&[])
     }
 
     fn consume(&mut self, amt: usize) {


### PR DESCRIPTION
Instead of the unreachable macro, when a 0 bytes block is encountered, the method returns an empty bytes array.

Fixes #4.
Possibly fixes #3.